### PR TITLE
Fix xpath indexing to 1-based and support adding attribute which does not exist in existing dom

### DIFF
--- a/src/dash/models/PatchManifestModel.js
+++ b/src/dash/models/PatchManifestModel.js
@@ -63,19 +63,20 @@ function PatchManifestModel() {
 
         // Go through the patch operations in order and parse their types out for usage
         return (patch.__children || []).map((node) => {
-            let type = Object.keys(node)[0];
+            let action = Object.keys(node)[0];
 
             // we only look add add/remove/replace types
-            if (type != 'add' && type != 'remove' && type != 'replace') {
-                console.log(`Ignoring node of invalid type: ${type}`);
+            if (action != 'add' && action != 'remove' && action != 'replace') {
+                console.log(`Ignoring node of invalid type: ${action}`);
                 return null;
             }
 
-            node = node[type];
+            node = node[action];
             let xpath = new SimpleXPath(node.sel);
+            let type = node.type || '';
 
             let value;
-            if (xpath.findsAttribute()) {
+            if (type.startsWith('@') || xpath.findsAttribute()) {
                 value = node.__text || '';
             } else {
                 value = node.__children.reduce((groups, child) => {
@@ -89,9 +90,9 @@ function PatchManifestModel() {
                 }, {});
             }
 
-            let operation = new PatchOperation(type, xpath, value);
+            let operation = new PatchOperation(action, xpath, type, value);
 
-            if (type == 'add') {
+            if (action == 'add') {
                 operation.position = node.pos;
             }
 

--- a/src/dash/vo/PatchOperation.js
+++ b/src/dash/vo/PatchOperation.js
@@ -33,15 +33,16 @@
  * @ignore
  */
 class PatchOperation {
-    constructor(type, xpath, value) {
-        this.type = type;
+    constructor(action, xpath, type, value) {
+        this.action = action;
         this.xpath = xpath;
+        this.type = type
         this.value = value;
         this.position = null;
     }
 
     getMpdTarget(root) {
-        let isSiblingOperation = this.type == 'remove' || this.type == 'replace' || this.position == 'before' || this.position == 'after';
+        let isSiblingOperation = this.action == 'remove' || this.action == 'replace' || this.position == 'before' || this.position == 'after';
         return this.xpath.getMpdTarget(root, isSiblingOperation);
     }
 }

--- a/src/dash/vo/SimpleXPath.js
+++ b/src/dash/vo/SimpleXPath.js
@@ -60,7 +60,7 @@ class SimpleXPath {
                             parsed.attribute.value = parsed.attribute.value.substring(1, parsed.attribute.value.length - 1);
                         }
                     } else {
-                        parsed.position = qualifier;
+                        parsed.position = parseInt(qualifier)-1;
                     }
                 }
 


### PR DESCRIPTION
1. XPath indexing is 1-based, eg:
```
   <add sel="/MPD/Period[@id=&apos;81&apos;]/AdaptationSet[2]/SegmentTemplate/SegmentTimeline">
      <S t="160162777" d="40106667"/>
   </add>
```
AdaptationSet[2] refers to 2nd element, i.e. index 1 in 0-based indexing

2. Adding new attribute which does not exist in existing DOM, see:
https://tools.ietf.org/html/rfc5261#section-4.3.2
```
<add sel="/MPD/Period[@id=&apos;81&apos;]/AdaptationSet[2]/SegmentTemplate/SegmentTimeline/S[4]" type="@r">1</add>
```